### PR TITLE
fix: broken Course Overview editor on Schedule & Details page (#2599)

### DIFF
--- a/src/schedule-and-details/index.jsx
+++ b/src/schedule-and-details/index.jsx
@@ -116,7 +116,6 @@ const ScheduleAndDetails = ({ intl, courseId }) => {
     license,
     language,
     subtitle,
-    overview,
     duration,
     selfPaced,
     startDate,
@@ -127,7 +126,6 @@ const ScheduleAndDetails = ({ intl, courseId }) => {
     instructorInfo,
     enrollmentStart,
     shortDescription,
-    aboutSidebarHtml,
     preRequisiteCourses,
     entranceExamEnabled,
     courseImageAssetPath,
@@ -139,6 +137,12 @@ const ScheduleAndDetails = ({ intl, courseId }) => {
   } = editedValues;
 
   useScrollToHashElement({ isLoading });
+  // No need to get overview and aboutSidebarHtml from editedValues
+  // As updating them re-renders TinyMCE
+  // Which causes issues with TinyMCE editor cursor position
+  // https://www.tiny.cloud/docs/tinymce/5/react/#initialvalue
+  const { overview: initialOverview } = courseDetails || {};
+  const { aboutSidebarHtml: initialAboutSidebarHtml } = courseDetails || {};
 
   if (isLoading) {
     // eslint-disable-next-line react/jsx-no-useless-fragment
@@ -276,12 +280,12 @@ const ScheduleAndDetails = ({ intl, courseId }) => {
                   )}
                   <IntroducingSection
                     title={title}
-                    overview={overview}
+                    overview={initialOverview}
                     duration={duration}
                     subtitle={subtitle}
                     introVideo={introVideo}
                     description={description}
-                    aboutSidebarHtml={aboutSidebarHtml}
+                    aboutSidebarHtml={initialAboutSidebarHtml}
                     shortDescription={shortDescription}
                     aboutPageEditable={aboutPageEditable}
                     sidebarHtmlEnabled={sidebarHtmlEnabled}


### PR DESCRIPTION
# Description
This PR fixes re-render issue with TinyMCE which cause lost in state and the cursor position

Backport: https://github.com/openedx/frontend-app-authoring/pull/2599

## Supporting information
(Internal) https://github.com/mitodl/hq/issues/9100

Short Video: https://github.mit.edu/storage/user/923/files/0c224c31-a86b-4346-a505-e697295d0083

Adding any text in course overview section in Schedule and Details Page causes the cursor to go back to initial point or at the very start of the editor.
This is because we are changing the initialValue of the Editor when we add/update any text which causes re-render.

Referece: https://www.tiny.cloud/docs/tinymce/5/react/#initialvalue

## Testing instructions
Steps to Reproduce

- Go to Studio Schedule and Details.
- Go to Course Overview
- Enter text in field
- Expected Behavior
- Expect to be able to enter text in field

## Actual Behavior
When enter text, the cursor pops back to the 1st position in the field at every character.